### PR TITLE
Remove YaST modules that are not maintenable

### DIFF
--- a/conclusion.md
+++ b/conclusion.md
@@ -97,8 +97,6 @@ YaST will offer quite some functionality for September's prototype included (but
 * Inspection of the systemd journal
 * Management of users and groups
 * Configuration of timezone, keyboard layout and language (if available in ALP)
-* Printers configuration
-* Administration of DNS server
 
 Apart from that, YaST will offer full capabilities for configuring the network in systems using
 Wicked (if that is possible in ALP).


### PR DESCRIPTION
While writing the conclusions document I just included all YaST modules that we have verified to work properly in a containerized environment.

But some of them are in a very bad state and/or not really maintained by the YaST Team, even in their current non-containerized form. So the Work Group for 1:1 System Management doesn't want to commit to include them as part of the containerized YaST for ALP (at least not in the first prototypes).

So let's simply remove those. I shouldn't have included them in the first version of the document simply because they worked.